### PR TITLE
Add tests for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Shadbala-radar
 Shadbala-radar
+
+## Running tests
+
+Ensure dependencies are installed (preferably inside a virtual environment):
+
+```bash
+pip install -r backend/requirements.txt
+pip install pytest
+```
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,28 @@
+import pytest
+from datetime import datetime
+
+pytest.importorskip("swisseph")
+pytest.importorskip("fastapi")
+
+from backend.app.shadbala import row
+from backend.app.main import app
+from fastapi.testclient import TestClient
+
+
+def test_row_returns_expected_structure():
+    result = row(datetime.utcnow(), lat=40.0, lon=0.0)
+    assert isinstance(result, dict)
+    assert "sun_long" in result
+    assert isinstance(result["sun_long"], float)
+
+
+def test_balas_endpoint_time_series_length():
+    client = TestClient(app)
+    hours = 1
+    resp = client.get("/balas", params={"hours_ahead": hours})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["interval"] == "5m"
+    assert len(payload["data"]) == hours * 12
+    assert isinstance(payload["data"][0], dict)
+    assert "sun_long" in payload["data"][0]


### PR DESCRIPTION
## Summary
- add tests for `row` function and `/balas` endpoint using `pytest`
- document test execution steps in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851e182ea9c832197ec35f071308d4a