### PR TITLE
Fix relative import when running main as script

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,12 @@
 from fastapi import FastAPI
 from datetime import datetime, timedelta
-from .shadbala import row
+
+try:
+    # When executed as part of the package
+    from .shadbala import row
+except ImportError:  # pragma: no cover - allow running file directly
+    # Fallback for running `python main.py` during development
+    from shadbala import row
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- make `backend/app/main.py` work when executed directly by trying a fallback absolute import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851e66018b88321b8fdc8c2e63c36d5