### PR TITLE
Enable CORS in backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -10,6 +11,13 @@ except ImportError:  # pragma: no cover - allow running file directly
     from shadbala import row
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/balas")
 def balas(hours_ahead: int | None = 24,


### PR DESCRIPTION
## Summary
- allow cross-origin requests from the frontend by enabling CORS in FastAPI

## Testing
- `pytest -q`
- `uvicorn backend.app.main:app --reload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68522d4224308321a8c98204b0c33660