### PR TITLE
Add basic D3 chart for Sun shadbala

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install -r backend/requirements.txt
 
 ### Frontend
 
-A placeholder `frontend` directory is provided. Once the JavaScript application is implemented, install its dependencies with:
+The frontend is a small React application that renders a D3 line chart showing the Sun's Shadbala components over time. Install its dependencies with:
 
 ```bash
 npm install

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import * as d3 from 'd3';
 
 function App() {
   const [start, setStart] = React.useState('');
@@ -7,6 +8,7 @@ function App() {
   const [lat, setLat] = React.useState('40.7128');
   const [lon, setLon] = React.useState('-74.0060');
   const [data, setData] = React.useState(null);
+  const svgRef = React.useRef(null);
 
   const submit = async (e) => {
     e.preventDefault();
@@ -14,6 +16,53 @@ function App() {
     const res = await fetch(`http://localhost:8000/balas?${params}`);
     setData(await res.json());
   };
+
+  React.useEffect(() => {
+    if (!data) return;
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('*').remove();
+
+    const width = 600;
+    const height = 300;
+    const margin = { top: 20, right: 30, bottom: 30, left: 40 };
+
+    const startTime = new Date(data.start);
+    const times = data.data.map((_, i) => new Date(startTime.getTime() + i * 5 * 60 * 1000));
+    const components = ['uccha', 'dig', 'kala', 'cheshta', 'naisargika', 'drik'];
+
+    const x = d3.scaleTime()
+      .domain(d3.extent(times))
+      .range([margin.left, width - margin.right]);
+
+    const y = d3.scaleLinear()
+      .domain([0, d3.max(data.data, row => d3.max(components, c => row['Sun'][c]))])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    const line = d3.line()
+      .x((d, i) => x(times[i]))
+      .y(d => y(d));
+
+    const colors = d3.schemeCategory10;
+
+    components.forEach((comp, idx) => {
+      const values = data.data.map(row => row['Sun'][comp]);
+      svg.append('path')
+        .datum(values)
+        .attr('fill', 'none')
+        .attr('stroke', colors[idx % colors.length])
+        .attr('stroke-width', 1.5)
+        .attr('d', line);
+    });
+
+    svg.append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x));
+
+    svg.append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y));
+  }, [data]);
 
   return (
     <div>
@@ -37,6 +86,7 @@ function App() {
         </label>
         <button type="submit">Fetch</button>
       </form>
+      <svg ref={svgRef} width="600" height="300"></svg>
       {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
     </div>
   );


### PR DESCRIPTION
## Summary
- render a D3 line chart in the frontend
- document the new chart functionality in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68522f1383888321b58c3607c2e5d6c8