### PR TITLE
Fix CORS for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ uvicorn backend.app.main:app --reload
 
 The API will be available at `http://localhost:8000`.
 
+When using the React frontend during development the site typically runs on
+`http://localhost:5173` (or `127.0.0.1:5173`). The backend is configured to
+allow CORS requests from these origins. Ensure the backend is running and the
+URL matches one of these origins; otherwise the browser may report a
+"Failed to fetch" error when submitting the form.
+
 ### Querying Shadbala values
 
 `/balas` returns rows sampled every five minutes. You may provide an

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,10 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=[
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- allow requests from `127.0.0.1:5173`
- document CORS origins in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68523c13c6288321ac90e7112f1e2eb4