### PR TITLE
Use env var for API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ npm install
 npm run dev
 ```
 
+Create a `.env` file in the `frontend` directory to configure the backend URL. It should define `VITE_API_URL`, e.g.
+
+```bash
+echo "VITE_API_URL=http://localhost:8000" > frontend/.env
+```
+
+An example file is provided at `frontend/.env.example`.
+
 The development server will start on http://localhost:5173 and automatically reload when files change.
 
 ## Running tests

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,10 +10,12 @@ function App() {
   const [data, setData] = React.useState(null);
   const svgRef = React.useRef(null);
 
+  const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
   const submit = async (e) => {
     e.preventDefault();
     const params = new URLSearchParams({ start, end, lat, lon });
-    const res = await fetch(`http://localhost:8000/balas?${params}`);
+    const res = await fetch(`${BASE_URL}/balas?${params}`);
     setData(await res.json());
   };
 


### PR DESCRIPTION
## Summary
- allow setting API base URL via `VITE_API_URL`
- add example env file for the frontend
- document how to configure the URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68523d5c645083218e81fa2cb7235187