### PR TITLE
Add httpx to backend dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ pytest
 
 ## Backend dependencies
 
-The backend uses a small set of Python packages. Exact versions are specified in [`backend/requirements.txt`](backend/requirements.txt). A `requirements.lock` file with the same pinned versions is also provided for convenience.
+The backend uses a small set of Python packages including FastAPI, uvicorn,
+pyswisseph, pandas and httpx. Exact versions are specified in
+[`backend/requirements.txt`](backend/requirements.txt). A `requirements.lock`
+file with the same pinned versions is also provided for convenience.
 
 ## License
 

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -2,3 +2,4 @@ fastapi==0.103.1
 uvicorn[standard]==0.23.2
 pyswisseph==2.10.03
 pandas==2.1.0
+httpx==0.27.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.103.1
 uvicorn[standard]==0.23.2
 pyswisseph==2.10.03
 pandas==2.1.0
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- add `httpx==0.27.0` to backend requirements and lock file
- document the new dependency in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685243cc26dc8321ae4193920fa57d29