### PR TITLE
Configure CORS via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,16 @@ uvicorn backend.app.main:app --reload
 
 The API will be available at `http://localhost:8000`.
 
+The backend reads a comma-separated list of allowed CORS origins from the
+`ALLOWED_ORIGINS` environment variable. If this variable is not set it
+defaults to `http://localhost:5173` and `http://127.0.0.1:5173`.
+
 When using the React frontend during development the site typically runs on
-`http://localhost:5173` (or `127.0.0.1:5173`). The backend is configured to
-allow CORS requests from these origins. Ensure the backend is running and the
-URL matches one of these origins; otherwise the browser may report a
-"Failed to fetch" error when submitting the form.
+`http://localhost:5173` (or `127.0.0.1:5173`). Ensure this URL is included in
+`ALLOWED_ORIGINS`; otherwise the browser may report a "Failed to fetch" error
+when submitting the form. When developing in GitHub Codespaces you will need to
+add the Codespaces URL for the frontend (for example
+`https://5173-<yourid>.app.github.dev`).
 
 ### Querying Shadbala values
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
+import os
 
 try:
     # When executed as part of the package
@@ -12,12 +13,18 @@ except ImportError:  # pragma: no cover - allow running file directly
 
 app = FastAPI()
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[
+origins_env = os.getenv("ALLOWED_ORIGINS")
+if origins_env:
+    allowed_origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+else:
+    allowed_origins = [
         "http://localhost:5173",
         "http://127.0.0.1:5173",
-    ],
+    ]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -27,3 +27,12 @@ def test_balas_endpoint_time_series_length():
     assert len(payload["data"]) == 12 + 1  # inclusive of start and end
     assert isinstance(payload["data"][0], dict)
     assert "Sun" in payload["data"][0]
+
+
+def test_allowed_origins_env(monkeypatch):
+    import importlib
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://example.com")
+    import backend.app.main as main
+    importlib.reload(main)
+    assert "https://example.com" in main.app.user_middleware[0].options["allow_origins"]
+


### PR DESCRIPTION
## Summary
- allow overriding CORS origins using the `ALLOWED_ORIGINS` env var
- mention the new configuration option in the README with Codespaces notes
- test that the middleware respects the environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685243dd3f088321a7e014de01284553