### PR TITLE
Update README for Codespaces backend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,14 @@ When using the React frontend during development the site typically runs on
 `ALLOWED_ORIGINS`; otherwise the browser may report a "Failed to fetch" error
 when submitting the form. When developing in GitHub Codespaces you will need to
 add the Codespaces URL for the frontend (for example
-`https://5173-<yourid>.app.github.dev`).
+`https://5173-<yourid>.app.github.dev`). The value in `ALLOWED_ORIGINS` must
+match the URL used to serve the React app. You can start the backend in a
+Codespace with:
+
+```bash
+export ALLOWED_ORIGINS=https://5173-<yourid>.app.github.dev
+uvicorn backend.app.main:app --reload
+```
 
 ### Querying Shadbala values
 


### PR DESCRIPTION
## Summary
- document how to start the backend from a Codespace
- clarify that `ALLOWED_ORIGINS` must match the URL used by the React app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852472e48008321ac584502168be181