### PR TITLE
Add GitHub preview domain to CORS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,11 +20,13 @@ else:
     allowed_origins = [
         "http://localhost:5173",
         "http://127.0.0.1:5173",
+        "https://fantastic-space-cod-5g57gw9764p9374gr-5173.app.github.dev",
     ]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- allow the GitHub preview URL as a default CORS origin
- enable credential support for CORS middleware

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68524853442c8321afefcaa500eecb73