### PR TITLE
Fix CORS allowed origins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ if codespace:
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- use configured origins when setting up CORS middleware

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6854662c8964832187c3e069a8872530