### PR TITLE
Add charts for Moon, Mercury and Venus

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pip install -r backend/requirements.txt
 
 ### Frontend
 
-The frontend is a small React application that renders a D3 line chart showing the Sun's Shadbala components over time. Install its dependencies with:
+The frontend is a small React application that renders D3 line charts showing the Shadbala components for the Sun, Moon, Mercury and Venus over time. Install its dependencies with:
 
 ```bash
 npm install

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,59 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import * as d3 from 'd3';
 
+function PlanetChart({ planet, data }) {
+  const svgRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!data) return;
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('*').remove();
+
+    const width = 600;
+    const height = 300;
+    const margin = { top: 20, right: 30, bottom: 30, left: 40 };
+
+    const startTime = new Date(data.start);
+    const times = data.data.map((_, i) => new Date(startTime.getTime() + i * 5 * 60 * 1000));
+    const components = ['uccha', 'dig', 'kala', 'cheshta', 'naisargika', 'drik'];
+
+    const x = d3.scaleTime()
+      .domain(d3.extent(times))
+      .range([margin.left, width - margin.right]);
+
+    const y = d3.scaleLinear()
+      .domain([0, d3.max(data.data, row => d3.max(components, c => row[planet][c]))])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    const line = d3.line()
+      .x((d, i) => x(times[i]))
+      .y(d => y(d));
+
+    const colors = d3.schemeCategory10;
+
+    components.forEach((comp, idx) => {
+      const values = data.data.map(row => row[planet][comp]);
+      svg.append('path')
+        .datum(values)
+        .attr('fill', 'none')
+        .attr('stroke', colors[idx % colors.length])
+        .attr('stroke-width', 1.5)
+        .attr('d', line);
+    });
+
+    svg.append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x));
+
+    svg.append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y));
+  }, [data, planet]);
+
+  return <svg ref={svgRef} width="600" height="300"></svg>;
+}
+
 function App() {
   const [start, setStart] = React.useState('');
   const [end, setEnd] = React.useState('');
@@ -9,7 +62,6 @@ function App() {
   const [lon, setLon] = React.useState('-74.0060');
   const [data, setData] = React.useState(null);
   const [error, setError] = React.useState(null);
-  const svgRef = React.useRef(null);
 
   const BASE_URL = import.meta.env.VITE_API_URL || 'https://fantastic-space-cod-5g57gw9764p9374gr-8000.app.github.dev';
 
@@ -30,52 +82,6 @@ function App() {
     }
   };
 
-  React.useEffect(() => {
-    if (!data) return;
-    const svg = d3.select(svgRef.current);
-    svg.selectAll('*').remove();
-
-    const width = 600;
-    const height = 300;
-    const margin = { top: 20, right: 30, bottom: 30, left: 40 };
-
-    const startTime = new Date(data.start);
-    const times = data.data.map((_, i) => new Date(startTime.getTime() + i * 5 * 60 * 1000));
-    const components = ['uccha', 'dig', 'kala', 'cheshta', 'naisargika', 'drik'];
-
-    const x = d3.scaleTime()
-      .domain(d3.extent(times))
-      .range([margin.left, width - margin.right]);
-
-    const y = d3.scaleLinear()
-      .domain([0, d3.max(data.data, row => d3.max(components, c => row['Sun'][c]))])
-      .nice()
-      .range([height - margin.bottom, margin.top]);
-
-    const line = d3.line()
-      .x((d, i) => x(times[i]))
-      .y(d => y(d));
-
-    const colors = d3.schemeCategory10;
-
-    components.forEach((comp, idx) => {
-      const values = data.data.map(row => row['Sun'][comp]);
-      svg.append('path')
-        .datum(values)
-        .attr('fill', 'none')
-        .attr('stroke', colors[idx % colors.length])
-        .attr('stroke-width', 1.5)
-        .attr('d', line);
-    });
-
-    svg.append('g')
-      .attr('transform', `translate(0,${height - margin.bottom})`)
-      .call(d3.axisBottom(x));
-
-    svg.append('g')
-      .attr('transform', `translate(${margin.left},0)`)
-      .call(d3.axisLeft(y));
-  }, [data]);
 
   return (
     <div>
@@ -99,10 +105,15 @@ function App() {
         </label>
         <button type="submit">Fetch</button>
       </form>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-      <svg ref={svgRef} width="600" height="300"></svg>
-      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
-    </div>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        {data && ['Sun', 'Moon', 'Mercury', 'Venus'].map(p => (
+          <div key={p} style={{ marginBottom: '2rem' }}>
+            <h2>{p}</h2>
+            <PlanetChart planet={p} data={data} />
+          </div>
+        ))}
+        {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
+      </div>
   );
 }
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -14,6 +14,8 @@ def test_row_returns_expected_structure():
     assert isinstance(result, dict)
     assert "Sun" in result
     assert set(result["Sun"].keys()) == {"uccha", "dig", "kala", "cheshta", "naisargika", "drik"}
+    for planet in ["Moon", "Mercury", "Venus"]:
+        assert planet in result
 
 
 def test_balas_endpoint_time_series_length():


### PR DESCRIPTION
## Summary
- expand README to mention multiple planets
- update frontend to render a chart for Sun, Moon, Mercury and Venus
- verify backend returns those planets in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685470305e34832193a1e5b55ac1cb6b