### PR TITLE
Enable sidereal Lahiri mode

### DIFF
--- a/backend/app/shadbala.py
+++ b/backend/app/shadbala.py
@@ -2,6 +2,9 @@ from datetime import datetime
 import math
 import swisseph as swe
 
+# Use sidereal calculations with the Lahiri ayanamsa
+swe.set_sid_mode(swe.SIDM_LAHIRI)
+
 # Exaltation degrees for planets
 EXALTATION_DEGREES = {
     "Sun": 10,

--- a/backend/tests/test_shadbala.py
+++ b/backend/tests/test_shadbala.py
@@ -13,6 +13,11 @@ class DummySwe:
     JUPITER = 4
     VENUS = 5
     SATURN = 6
+    SIDM_LAHIRI = 1
+
+    def set_sid_mode(self, mode, t0=0, ayan_t0=0):
+        """Dummy implementation for sidereal mode."""
+        self.sid_mode = mode
 
     def julday(self, y, m, d, h):
         return 0.0


### PR DESCRIPTION
## Summary
- switch Swiss Ephemeris to Lahiri sidereal mode
- add dummy `set_sid_mode` and constant to test stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685477b4fe5c8321809f4dc81d2e4b5b