### PR TITLE
Fix negative drik bala

### DIFF
--- a/backend/app/shadbala.py
+++ b/backend/app/shadbala.py
@@ -59,6 +59,10 @@ PLANETS = [
     ("Saturn", swe.SATURN),
 ]
 
+# Simple benefic/malefic categorisation used for Drik bala
+BENEFIC_PLANETS = {"Jupiter", "Venus"}
+MALEFIC_PLANETS = {"Mars", "Saturn"}
+
 
 def _angle_diff(a: float, b: float) -> float:
     """Return the absolute difference between two angles within 0..180."""
@@ -140,14 +144,19 @@ def _cheshta_bala(speed: float, planet: str) -> float:
     return ratio * 60.0
 
 
-def _drik_bala(plon: float, others: list[float]) -> float:
-    """Aspect strength based on separations from other planets."""
+def _drik_bala(plon: float, others: dict[str, float]) -> float:
+    """Aspect strength based on separations from other planets.
+
+    Benefic aspects contribute positively while malefic aspects reduce the score.
+    """
     if not others:
         return 0.0
     total = 0.0
-    for other in others:
+    for name, other in others.items():
         diff = _angle_diff(plon, other)
         strength = max(0.0, 60.0 - diff / 3.0)
+        if name in MALEFIC_PLANETS:
+            strength *= -1
         total += strength
     return total / len(others)
 
@@ -185,7 +194,7 @@ def row(timestamp: datetime, lat: float, lon: float):
         }
 
     for name, pos in positions.items():
-        others = [p for pname, p in positions.items() if pname != name]
+        others = {pname: p for pname, p in positions.items() if pname != name}
         results[name]["drik"] = _drik_bala(pos, others)
 
     return results

--- a/backend/tests/test_drik.py
+++ b/backend/tests/test_drik.py
@@ -1,0 +1,33 @@
+import sys
+import importlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+class DummySwe:
+    SUN = 0
+    MOON = 1
+    MARS = 2
+    MERCURY = 3
+    JUPITER = 4
+    VENUS = 5
+    SATURN = 6
+    SIDM_LAHIRI = 1
+    def set_sid_mode(self, mode, t0=0, ayan_t0=0):
+        pass
+    def julday(self, y,m,d,h):
+        return 0.0
+    def calc_ut(self, jd, pid):
+        return (0,0,0,0)
+
+def load_module():
+    dummy = DummySwe()
+    sys.modules['swisseph'] = dummy
+    shadbala = importlib.import_module('backend.app.shadbala')
+    shadbala.swe = dummy
+    return shadbala
+
+def test_drik_bala_negative():
+    shadbala = load_module()
+    result = shadbala._drik_bala(10, {'Mars': 10})
+    assert result == -60.0


### PR DESCRIPTION
## Summary
- account for benefic vs malefic planets when computing drik bala
- test negative contributions for malefic aspect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855ab4b2a008321bf8d657c6f083ec5