### PR TITLE
Remove tables and arrange charts in grid

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -88,34 +88,7 @@ function PlanetChart({ planet, data }) {
   return <svg ref={svgRef} width="450" height="300" className="chart"></svg>;
 }
 
-function PlanetTable({ planet, data }) {
-  const startTime = new Date(data.start);
-  const times = data.data.map((_, i) => new Date(startTime.getTime() + i * 5 * 60 * 1000));
-  const components = ['uccha', 'dig', 'kala', 'cheshta', 'naisargika', 'drik'];
-
-  return (
-    <table className="bala-table">
-      <thead>
-        <tr>
-          <th>Time</th>
-          {components.map(c => (
-            <th key={c}>{c}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {data.data.map((row, i) => (
-          <tr key={i}>
-            <td>{times[i].toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</td>
-            {components.map(c => (
-              <td key={c}>{Math.abs(row[planet][c]).toFixed(2)}</td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}
+// Table view removed as charts are now displayed without accompanying tables
 
 
 function App() {
@@ -176,12 +149,11 @@ function App() {
       </form>
         {error && <p style={{ color: 'red' }}>{error}</p>}
         {data && (
-          <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between' }}>
+          <div className="charts-grid">
             {PLANETS.map(p => (
-              <div key={p} style={{ flex: '0 0 48%' }} className="chart-container">
+              <div key={p} className="chart-container">
                 <h2>{p}</h2>
                 <PlanetChart planet={p} data={data} />
-                <PlanetTable planet={p} data={data} />
               </div>
             ))}
           </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -54,9 +54,15 @@ button:hover {
 .chart-container {
   background-color: #fff;
   padding: 1rem;
-  margin-bottom: 2rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 1rem;
 }
 
 svg.chart {
@@ -64,19 +70,3 @@ svg.chart {
   border: 1px solid #ddd;
 }
 
-table.bala-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 1rem;
-}
-
-table.bala-table th,
-table.bala-table td {
-  border: 1px solid #ccc;
-  padding: 0.3rem 0.5rem;
-  text-align: center;
-}
-
-table.bala-table th {
-  background-color: #f0f0f0;
-}


### PR DESCRIPTION
## Summary
- delete the planet data table component
- display charts in a two-column grid
- clean up styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855c17b7af48321b4fa7cd65b380d11