### PR TITLE
Allow Drik Bala results beyond +/-60

### DIFF
--- a/backend/app/shadbala.py
+++ b/backend/app/shadbala.py
@@ -197,7 +197,7 @@ def _drik_bala(plon: float, planet: str, positions: dict[str, float]) -> float:
             total += strength
         elif name in MALEFIC_PLANETS:
             total -= strength
-    return total / len(others)
+    return total
 
 
 def row(timestamp: datetime, lat: float, lon: float):

--- a/tests/test_drik_bala.py
+++ b/tests/test_drik_bala.py
@@ -46,7 +46,7 @@ def test_drik_bala_signed_average():
         "Saturn": 0.0,
     }
     result = shadbala._drik_bala(0.0, "Sun", positions)
-    assert result == pytest.approx(20.0)
+    assert result == pytest.approx(120.0)
 
 
 def test_drik_bala_no_others():


### PR DESCRIPTION
## Summary
- remove averaging in `_drik_bala` so Drik Bala may exceed the range of -60..60
- update tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855c99dd7208321b51f12854de554d0