### PR TITLE
Add true node toggle for Rahu/Ketu

### DIFF
--- a/backend/tests/test_drik.py
+++ b/backend/tests/test_drik.py
@@ -12,6 +12,8 @@ class DummySwe:
     JUPITER = 4
     VENUS = 5
     SATURN = 6
+    MEAN_NODE = 7
+    TRUE_NODE = 8
     SIDM_LAHIRI = 1
     def set_sid_mode(self, mode, t0=0, ayan_t0=0):
         pass

--- a/backend/tests/test_shadbala.py
+++ b/backend/tests/test_shadbala.py
@@ -13,6 +13,8 @@ class DummySwe:
     JUPITER = 4
     VENUS = 5
     SATURN = 6
+    MEAN_NODE = 7
+    TRUE_NODE = 8
     SIDM_LAHIRI = 1
 
     def set_sid_mode(self, mode, t0=0, ayan_t0=0):
@@ -31,6 +33,8 @@ class DummySwe:
             4: (130, 0, 1, 1),
             5: (160, 0, 1, 1),
             6: (190, 0, 1, 1),
+            7: (220, 0, 1, 1),
+            8: (40, 0, 1, 1),
         }
         return longs[pid]
 


### PR DESCRIPTION
## Summary
- support optional mean/true node calculation in `row`
- provide dummy constants for lunar nodes in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855cc32397c83219a381ce2875263c4