### PR TITLE
Enable node options in drik bala

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,6 +46,7 @@ def get_balas(
     end: str | None = None,
     lat: float = 40.7128,
     lon: float = -74.0060,
+    use_true_node: bool = False,
 ):
     """Return shadbala rows every 5 minutes.
 
@@ -55,7 +56,7 @@ def get_balas(
     timezone. The range may not exceed 24 hours.
     """
 
-    start_utc, frames = _collect_data(hours_ahead, start, end, lat, lon)
+    start_utc, frames = _collect_data(hours_ahead, start, end, lat, lon, use_true_node)
     return {"start": start_utc.isoformat(), "interval": "5m", "data": frames}
 
 
@@ -65,6 +66,7 @@ def _collect_data(
     end: str | None,
     lat: float,
     lon: float,
+    use_true_node: bool,
 ):
     tz = ZoneInfo("America/New_York")
 
@@ -91,14 +93,17 @@ def _collect_data(
         frames = []
         current = start_utc
         while current <= end_utc:
-            frames.append(row(current, lat, lon))
+            frames.append(row(current, lat, lon, use_true_node=use_true_node))
             current += timedelta(minutes=5)
         return start_utc, frames
 
     now = datetime.utcnow()
     if hours_ahead is None:
         hours_ahead = 24
-    frames = [row(now + timedelta(minutes=5 * i), lat, lon) for i in range(int(hours_ahead * 12))]
+    frames = [
+        row(now + timedelta(minutes=5 * i), lat, lon, use_true_node=use_true_node)
+        for i in range(int(hours_ahead * 12))
+    ]
     return now, frames
 
 
@@ -109,10 +114,11 @@ def get_balas_csv(
     end: str | None = None,
     lat: float = 40.7128,
     lon: float = -74.0060,
+    use_true_node: bool = False,
 ):
     """Return shadbala rows as CSV."""
 
-    start_utc, frames = _collect_data(hours_ahead, start, end, lat, lon)
+    start_utc, frames = _collect_data(hours_ahead, start, end, lat, lon, use_true_node)
 
     output = StringIO()
     writer = csv.writer(output)

--- a/backend/app/shadbala.py
+++ b/backend/app/shadbala.py
@@ -60,10 +60,11 @@ PLANETS = [
 ]
 
 # Simple benefic/malefic categorisation used for Drik bala
-# Moon and Mercury are considered benefic here while the Sun is treated as
-# neutral. Rahu and Ketu are currently ignored.
+# Moon and Mercury are considered benefic while the Sun is treated as neutral.
+# Rahu and Ketu are included as malefics when the nodes are added to the
+# positions dictionary.
 BENEFIC_PLANETS = {"Jupiter", "Venus", "Mercury", "Moon"}
-MALEFIC_PLANETS = {"Mars", "Saturn"}
+MALEFIC_PLANETS = {"Mars", "Saturn", "Rahu", "Ketu"}
 
 # Mapping of Python weekday numbers (Monday=0) to planetary lords
 WEEKDAY_LORD = {
@@ -260,11 +261,12 @@ def row(timestamp: datetime, lat: float, lon: float, use_true_node: bool = False
     else:
         rahu_lon = node_calc[0]
     ketu_lon = (rahu_lon + 180.0) % 360.0
-    # Uncomment the following lines to include the nodes in Drik bala
-    # positions["Rahu"] = rahu_lon
-    # positions["Ketu"] = ketu_lon
+    # Include the lunar nodes so they contribute to Drik bala calculations
+    positions["Rahu"] = rahu_lon
+    positions["Ketu"] = ketu_lon
 
     for name, pos in positions.items():
-        results[name]["drik"] = _drik_bala(pos, name, positions)
+        if name in results:
+            results[name]["drik"] = _drik_bala(pos, name, positions)
 
     return results

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -96,6 +96,7 @@ function App() {
   const [end, setEnd] = React.useState('');
   const [lat, setLat] = React.useState('40.7128');
   const [lon, setLon] = React.useState('-74.0060');
+  const [useTrueNode, setUseTrueNode] = React.useState(false);
   const [data, setData] = React.useState(null);
   const [error, setError] = React.useState(null);
 
@@ -103,7 +104,7 @@ function App() {
 
   const submit = async (e) => {
     e.preventDefault();
-    const params = new URLSearchParams({ start, end, lat, lon });
+    const params = new URLSearchParams({ start, end, lat, lon, use_true_node: useTrueNode });
     setError(null);
     try {
       const res = await fetch(`${BASE_URL}/balas?${params}`);
@@ -119,7 +120,7 @@ function App() {
   };
 
   const exportCsv = () => {
-    const params = new URLSearchParams({ start, end, lat, lon });
+    const params = new URLSearchParams({ start, end, lat, lon, use_true_node: useTrueNode });
     window.location.href = `${BASE_URL}/balas.csv?${params}`;
   };
 
@@ -143,6 +144,14 @@ function App() {
         <label>
           Lon
           <input type="number" step="0.0001" value={lon} onChange={(e) => setLon(e.target.value)} />
+        </label>
+        <label>
+          Use True Node
+          <input
+            type="checkbox"
+            checked={useTrueNode}
+            onChange={(e) => setUseTrueNode(e.target.checked)}
+          />
         </label>
         <button type="submit">Fetch</button>
         <button type="button" onClick={exportCsv}>Export CSV</button>


### PR DESCRIPTION
## Summary
- treat Rahu and Ketu as malefics and include them when calculating Drik Bala
- expose `use_true_node` through the backend API
- add a checkbox in the frontend form for using the true node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855ceae444083219bc34142e83bef5d