### PR TITLE
Fix drik bala aspect direction

### DIFF
--- a/backend/app/shadbala.py
+++ b/backend/app/shadbala.py
@@ -212,8 +212,8 @@ def _drik_bala(plon: float, planet: str, positions: dict[str, float]) -> float:
 
     total = 0.0
     for name, other in others.items():
-        # measure from the source planet (other) to the target planet (plon)
-        diff = (plon - other + 360.0) % 360.0
+        # measure from the aspecting planet toward the target planet
+        diff = (other - plon + 360.0) % 360.0
         aspects = ASPECTS.get(name, DEFAULT_ASPECT)
         for angle, weight in aspects.items():
             if abs(diff - angle) <= TOL:

--- a/tests/test_drik_bala.py
+++ b/tests/test_drik_bala.py
@@ -48,8 +48,8 @@ def test_drik_bala_signed_average():
     result = shadbala._drik_bala(0.0, "Sun", positions)
     # With aspects measured from the aspecting planet to the target,
     # benefics contribute positively while malefics reduce the score.
-    # The configuration below should yield a total of 216.
-    assert result == pytest.approx(216.0)
+    # The configuration below should yield a total of 96.
+    assert result == pytest.approx(96.0)
 
 
 def test_drik_bala_no_others():


### PR DESCRIPTION
## Summary
- fix `_drik_bala` angle measurement so aspects are computed from the aspecting planet to the target
- update tests for new drik bala calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855e2383dd48321a573dd48d3e77555